### PR TITLE
Se añade la posibilidad de establecer un límite de consumo de red

### DIFF
--- a/addon/doc/es/readme.md
+++ b/addon/doc/es/readme.md
@@ -12,6 +12,11 @@ Al iniciar el monitoreo, se puede pulsar el mismo atajo y se dirá la cantidad d
 
 ## Changelog
 
+### 2.1.1
+
+* Se traduce el compelmento al ucraniano, gracias a George-br.
+* Se traduce el compelmento al ruso, gracias a Kostenkov-2021.
+
 ### 2.1
 
 Se añade la funcionalidad para presentar correctamente las horas.

--- a/addon/globalPlugins/Internet/__init__.py
+++ b/addon/globalPlugins/Internet/__init__.py
@@ -87,8 +87,12 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         )
         def callback(result):
             if result == wx.ID_OK:
-                limit = dialog.GetValue()
-                self.mb_limit = int(limit)
+                limit = int(dialog.GetValue())
+                if limit <= 0:
+                    ui.message(_("Ingrese un límite válido (mayor a 0)."))
+                    return
+
+                self.mb_limit = limit
                 self.verify_thread = threading.Thread(target=self.checkLimit)
                 self.verify_thread.start()
                 # Translators: Message that indicates to the user that the network consumption limit has been set correctly.

--- a/addon/globalPlugins/Internet/timer.py
+++ b/addon/globalPlugins/Internet/timer.py
@@ -1,0 +1,17 @@
+import time
+
+class Timer:
+	def __init__(self):
+		self.last_time = time.time()
+		self.Elapsed = 0
+	def elapsed(self, interval, ms = True):
+		current_time = time.time()
+		new_time = (current_time - self.last_time) * 1000 if ms else (current_time - self.last_time)
+		if new_time >= interval:
+			self.last_time = current_time
+			self.Elapsed = new_time
+			return True
+		return False
+
+	def restart(self):
+		self.last_time = time.time()


### PR DESCRIPTION
Se añadió la posibilidad de que con el gesto nvda+shift+w se lanza un cuadro de texto en el que se puede establecer un límite de consumo, para que así el usuario sea avisado cuando llegue o exceda este límite con un mensaje y un tono.